### PR TITLE
Add direction in licensing terms

### DIFF
--- a/packages/storykit/src/components/LicenseTerms/LicenseTerms.tsx
+++ b/packages/storykit/src/components/LicenseTerms/LicenseTerms.tsx
@@ -74,20 +74,29 @@ const policiesStyles = cva("", {
   },
 })
 
+const directionStyles = cva("", {
+  variants: {
+    direction: {
+      row: "skLicenseTerms--row",
+      column: "skLicenseTerms--col",
+    },
+  },
+})
+
 export type LicenseTermsProps = {
-  size?: "small" | "medium" | "large"
   type: PolicyType
   direction?: "row" | "column"
+  size?: "small" | "medium" | "large"
 }
 
-function LicenseTerms({ size = "medium", type, direction = "column" }: LicenseTermsProps) {
+function LicenseTerms({ type, direction = "column", size = "medium" }: LicenseTermsProps) {
   const iconWidth = size === "small" ? 16 : size === "medium" ? 20 : 24
 
   return (
-    <div className={cn("skLicenseTerms", policiesStyles({ size }), direction === "column" ? "flex-col" : "flex-row")}>
-      <div className="skLicenseTerms__properties">
+    <div className={cn("skLicenseTerms", policiesStyles({ size }))}>
+      <div className={cn("skLicenseTerms__properties", directionStyles({ direction }))}>
         {ShowCans({ type }).length ? (
-          <>
+          <div>
             <div className="skLicenseTerms__item-list-title">Others Can</div>
             <div className="skLicenseTerms__list">
               {ShowCans({ type }).map((can, index) => (
@@ -97,16 +106,18 @@ function LicenseTerms({ size = "medium", type, direction = "column" }: LicenseTe
                 </div>
               ))}
             </div>
-          </>
+          </div>
         ) : null}
-        <div className="skLicenseTerms__item-list-title">Others Cannot</div>
-        <div className="skLicenseTerms__list">
-          {ShowCannots({ type }).map((can, index) => (
-            <div key={index} className="skLicenseTerms__property skLicenseTerms__property--cannot">
-              <CircleMinus width={iconWidth} />
-              <span>{can}</span>
-            </div>
-          ))}
+        <div>
+          <div className="skLicenseTerms__item-list-title">Others Cannot</div>
+          <div className="skLicenseTerms__list">
+            {ShowCannots({ type }).map((can, index) => (
+              <div key={index} className="skLicenseTerms__property skLicenseTerms__property--cannot">
+                <CircleMinus width={iconWidth} />
+                <span>{can}</span>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/packages/storykit/src/components/LicenseTerms/__docs__/LicenseTerms.stories.tsx
+++ b/packages/storykit/src/components/LicenseTerms/__docs__/LicenseTerms.stories.tsx
@@ -25,5 +25,6 @@ export const Select: Story = {
   args: {
     size: "medium",
     type: POLICY_TYPE.COMMERCIAL_REMIX as PolicyType,
+    direction: "column",
   },
 }

--- a/packages/storykit/src/components/LicenseTerms/styles.css
+++ b/packages/storykit/src/components/LicenseTerms/styles.css
@@ -3,6 +3,14 @@
 
   .skLicenseTerms__properties {
     @apply flex flex-col pt-2 gap-2;
+
+    &.skLicenseTerms--row {
+      @apply flex flex-row;
+    }
+
+    &.skLicenseTerms--col {
+      @apply flex flex-col;
+    }
   }
 
   .skLicenseTerms__item-list-title {


### PR DESCRIPTION
- add `direction` prop for `LicenseTerms`
![image](https://github.com/storyprotocol/storykit/assets/4248780/095aefb7-ed27-4d0e-a937-e0c967724c43)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `direction` property to the License Terms component, allowing users to choose between row and column layouts.

- **Style**
  - Introduced new CSS classes for row and column layouts in the License Terms component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->