### PR TITLE
Add tests for license terms

### DIFF
--- a/packages/storykit/src/components/LicenseTerms/LicenseTerms.tsx
+++ b/packages/storykit/src/components/LicenseTerms/LicenseTerms.tsx
@@ -6,7 +6,7 @@ import { CircleCheck, CircleMinus } from "lucide-react"
 import "../../global.css"
 import "./styles.css"
 
-const CANS = {
+export const CANS = {
   REMIX: "Remix this work",
   INCLUDE: "Include this work in their own work(s)",
   CREDIT: "Credit you appropriately",
@@ -36,7 +36,7 @@ const ShowCans = ({ type }: { type: string }) => {
   }
 }
 
-const CANNOTS = {
+export const CANNOTS = {
   RESELL: "Resell your original work",
   COMMERCIALIZE: "Commercialize the remix",
   CLAIM_AS_ORIGINAL: "Claim credit for the remix (as original work)",

--- a/packages/storykit/src/components/LicenseTerms/__docs__/LicenseTerms.stories.tsx
+++ b/packages/storykit/src/components/LicenseTerms/__docs__/LicenseTerms.stories.tsx
@@ -3,24 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { expect, waitFor } from "@storybook/test"
 
 import Example from "../LicenseTerms"
-
-const CANS = {
-  REMIX: "Remix this work",
-  INCLUDE: "Include this work in their own work(s)",
-  CREDIT: "Credit you appropriately",
-  DISTRIBUTE: "Distribute their remix anywhere",
-  PURCHASE_RIGHTS: "Purchase the right to use your creation (for a price you set) and register it into Story Protocol",
-  CREATOR_CREDIT: "Credit you as the creator",
-  PUBLISH: "Display / publish the work in any medium",
-}
-
-const CANNOTS = {
-  RESELL: "Resell your original work",
-  COMMERCIALIZE: "Commercialize the remix",
-  CLAIM_AS_ORIGINAL: "Claim credit for the remix (as original work)",
-  CLAIM: "Claim your work as their own",
-  REMIX: "Create remixes of the commercial use.",
-}
+import { CANS, CANNOTS } from "../LicenseTerms"
 
 const meta = {
   title: "UI/LicenseTerms",


### PR DESCRIPTION
This PR is to add tests for license terms, check the terms for the following license types.
1, NON_COMMERCIAL_SOCIAL_REMIXING
2, COMMERCIAL_USE
3, COMMERCIAL_REMIX
4, OPEN_DOMAIN
5, NO_DERIVATIVE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new licensing terms with specific permissions and restrictions.
  - Introduced new stories to demonstrate different types of licensing terms:
    - Non-commercial Social Remix Terms
    - Commercial Use Terms
    - Commercial Remix Terms
    - Open Domain Terms
    - No Derivative Terms
<!-- end of auto-generated comment: release notes by coderabbit.ai -->