### PR TITLE
find API_BASE_URL from process.env

### DIFF
--- a/packages/storykit/package.json
+++ b/packages/storykit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storyprotocol/storykit",
   "author": "storyprotocol engineering <eng@storyprotocol.xyz>",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/storykit/src/lib/api.ts
+++ b/packages/storykit/src/lib/api.ts
@@ -1,6 +1,9 @@
 import { QueryOptions, ResourceType } from "../types/api"
 import { API_BASE_URL } from "./constants"
 
+const API_URL =
+  process.env.STORYBOOK_API_BASE_URL || process.env.NEXT_PUBLIC_API_BASE_URL || process.env.API_BASE_URL || API_BASE_URL
+
 const API_KEY =
   process.env.STORYBOOK_STORY_PROTOCOL_X_API_KEY ||
   process.env.NEXT_PUBLIC_STORY_PROTOCOL_X_API_KEY ||
@@ -9,7 +12,7 @@ const API_KEY =
 
 export async function getResource(resourceName: ResourceType, resourceId: string) {
   try {
-    const res = await fetch(`${API_BASE_URL}/api/v1/${resourceName}/${resourceId}`, {
+    const res = await fetch(`${API_URL}/api/v1/${resourceName}/${resourceId}`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -27,7 +30,7 @@ export async function getResource(resourceName: ResourceType, resourceId: string
 
 export async function listResource(resourceName: ResourceType, options?: QueryOptions) {
   try {
-    const res = await fetch(`${API_BASE_URL}/api/v1/${resourceName}`, {
+    const res = await fetch(`${API_URL}/api/v1/${resourceName}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/packages/storykit/src/lib/constants.ts
+++ b/packages/storykit/src/lib/constants.ts
@@ -1,1 +1,1 @@
-export const API_BASE_URL = "https://edge.stg.storyprotocol.net"
+export const API_BASE_URL = "https://api.storyprotocol.net"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Updated package version from "0.1.16" to "0.1.17" in `@storyprotocol/storykit`.
    - Introduced a new `API_URL` constant in `api.ts` for dynamic API base URL prioritization.
    - Updated URL construction in `getResource` and `listResource` functions to use `API_URL` instead of `API_BASE_URL`.
    - Updated `API_BASE_URL` constant from `"https://edge.stg.storyprotocol.net"` to `"https://api.storyprotocol.net"`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->