### PR TITLE
fix: add Open Use PIL and fix commercial use condition

### DIFF
--- a/packages/storykit/src/lib/utils.ts
+++ b/packages/storykit/src/lib/utils.ts
@@ -35,11 +35,11 @@ export function camelize(str: string) {
 export function getPilFlavorByLicenseTerms(pilTerms: PILTerms): PilFlavor {
   const { commercialUse, derivativesAllowed, derivativesAttribution, commercialRevenueShare } = pilTerms
 
-  if (!commercialUse && derivativesAllowed && derivativesAttribution) {
-    return PIL_FLAVOR.NON_COMMERCIAL_SOCIAL_REMIXING
+  if (!commercialUse && derivativesAllowed) {
+    return derivativesAttribution ? PIL_FLAVOR.NON_COMMERCIAL_SOCIAL_REMIXING : PIL_FLAVOR.OPEN_USE
   }
 
-  if (commercialUse && derivativesAllowed && derivativesAttribution && commercialRevenueShare === 0) {
+  if (commercialUse && derivativesAllowed && !derivativesAttribution && commercialRevenueShare === 0) {
     // TODO: commercial use should check that mintingFee is set, currently not received from the API
     return PIL_FLAVOR.COMMERCIAL_USE
   }

--- a/packages/storykit/src/types/assets.ts
+++ b/packages/storykit/src/types/assets.ts
@@ -5,7 +5,7 @@ export enum PIL_FLAVOR {
   COMMERCIAL_USE = "Commercial Use",
   COMMERCIAL_REMIX = "Commercial Remix",
   CUSTOM = "Custom",
-  // OPEN_DOMAIN = "Open Domain",
+  OPEN_USE = "Open Use",
   // NO_DERIVATIVE = "No Derivative",
 }
 
@@ -14,6 +14,7 @@ export type PilFlavor =
   | PIL_FLAVOR.COMMERCIAL_USE
   | PIL_FLAVOR.COMMERCIAL_REMIX
   | PIL_FLAVOR.CUSTOM
+  | PIL_FLAVOR.OPEN_USE
 
 export type Asset = {
   id: Address


### PR DESCRIPTION
This PR updates the logic for determining PIL flavors based on license terms in the `getPilFlavorByLicenseTerms`.

The changes include:
- Adjusted conditions for `NON_COMMERCIAL_SOCIAL_REMIXING` and `COMMERCIAL_USE` flavors to ensure better alignment with the requirements
- Add new flavor,`OPEN_USE`

The determination of  `COMMERCIAL_USE` flavor is now explicitly based on the conditions outlined in the [PILFlavors.sol contract](https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/lib/PILFlavors.sol#L166C17-L166C39).