### PR TITLE
fix: `derivativesAllowed` condition for determining `commercial_use` license

### DIFF
--- a/packages/storykit/package.json
+++ b/packages/storykit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storyprotocol/storykit",
   "author": "storyprotocol engineering <eng@storyprotocol.xyz>",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/storykit/src/lib/utils.ts
+++ b/packages/storykit/src/lib/utils.ts
@@ -39,7 +39,7 @@ export function getPilFlavorByLicenseTerms(pilTerms: PILTerms): PilFlavor {
     return derivativesAttribution ? PIL_FLAVOR.NON_COMMERCIAL_SOCIAL_REMIXING : PIL_FLAVOR.OPEN_USE
   }
 
-  if (commercialUse && derivativesAllowed && !derivativesAttribution && commercialRevenueShare === 0) {
+  if (commercialUse && !derivativesAllowed && !derivativesAttribution && commercialRevenueShare === 0) {
     // TODO: commercial use should check that mintingFee is set, currently not received from the API
     return PIL_FLAVOR.COMMERCIAL_USE
   }


### PR DESCRIPTION
This PR fixes the conditions for determining the `COMMERCIAL_USE` license to align with the implementation in [PILFlavors.sol](https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/lib/PILFlavors.sol#L148-L173)