### PR TITLE
Fix: add boundary protection for customTheme file

### DIFF
--- a/examples/custom-theme/app/IpHeader.tsx
+++ b/examples/custom-theme/app/IpHeader.tsx
@@ -8,7 +8,11 @@ export default function IpHeader() {
       <h2 className="text-xs text-gray-500">By {nftData?.owners[0].owner_address}</h2>
       {nftData?.previews.image_medium_url ? 
         // eslint-disable-next-line @next/next/no-img-element
-        <img src={nftData.previews.image_medium_url} alt={nftData.name} className="w-full aspect-video object-contain border border-gray-200 rounded-md my-2" /> 
+        <img 
+          src={nftData.previews.image_medium_url} 
+          alt={nftData?.name || "No image available"} 
+          className="w-full aspect-video object-contain border border-gray-200 rounded-md my-2" 
+        /> 
       : null}
     </div>
   )


### PR DESCRIPTION
It will show `undefined` when `nftData` object has not exist or has not `name` attribute.

before:
```
<img src={nftData.previews.image_medium_url} alt={nftData.name} className="w-full aspect-video object-contain border border-gray-200 rounded-md my-2" /> 
```
After: 
```
<img 
    src={nftData.previews.image_medium_url} 
    alt={nftData?.name || "No image available"} 
    className="w-full aspect-video object-contain border border-gray-200 rounded-md my-2" 
 /> 
 ```