### PR TITLE
Fix `expiration` text format in `LicenseTermsList 

### DIFF
--- a/packages/storykit/package.json
+++ b/packages/storykit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storyprotocol/storykit",
   "author": "storyprotocol engineering <eng@storyprotocol.xyz>",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/storykit/src/components/LicenseTermsList/LicenseTermsList.tsx
+++ b/packages/storykit/src/components/LicenseTermsList/LicenseTermsList.tsx
@@ -21,18 +21,36 @@ export const DESCRIPTIONS: { [key: string]: string } = {
   DERIVATIVES_RECIPROCAL: "Enforce that derivatives have the same License Terms that you provide them",
   NEVER_EXPIRES: "This license never expires",
 }
+function getTimezoneAbbr(date: Date) {
+  const longName =
+    date
+      .toLocaleDateString("en-US", {
+        timeZoneName: "long",
+        timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      })
+      .split(",")[1]
+      ?.trim() || ""
 
+  return longName
+    .split(" ")
+    .map((word) => word[0])
+    .join("")
+}
 const convertExpiration = (expiration: string): string => {
   if (expiration == "never" || expiration == "0") {
     return DESCRIPTIONS.NEVER_EXPIRES
   }
 
-  const expirationDateString = new Date(Number(expiration)).toLocaleDateString(undefined, {
+  const date = new Date(Number(expiration))
+  const expirationDateString = date.toLocaleDateString("en-US", {
     year: "numeric",
     month: "long",
     day: "numeric",
   })
-  return `This license expires in ${expirationDateString}`
+
+  const timezone = getTimezoneAbbr(date)
+
+  return `This license expires in ${expirationDateString} (${timezone})`
 }
 
 const DescribeTerms = (selectedLicenseTerms: PILTerms) => {

--- a/packages/storykit/src/components/LicenseTermsList/LicenseTermsList.tsx
+++ b/packages/storykit/src/components/LicenseTermsList/LicenseTermsList.tsx
@@ -26,7 +26,13 @@ const convertExpiration = (expiration: string): string => {
   if (expiration == "never" || expiration == "0") {
     return DESCRIPTIONS.NEVER_EXPIRES
   }
-  return expiration
+
+  const expirationDateString = new Date(Number(expiration)).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  })
+  return `This license expires in ${expirationDateString}`
 }
 
 const DescribeTerms = (selectedLicenseTerms: PILTerms) => {

--- a/packages/storykit/src/components/LicenseTermsList/__docs__/LicenseTermsList.stories.tsx
+++ b/packages/storykit/src/components/LicenseTermsList/__docs__/LicenseTermsList.stories.tsx
@@ -1,6 +1,7 @@
 import {
   commercialRemixingLicenseTerms,
   commercialUseLicenseTerms,
+  commercialUseLicenseTermsWithExpiration,
   noLicenseTerms,
   nonCommercialSocialRemixingLicenseTerms,
 } from "@/constants/pil-flavors"
@@ -37,12 +38,14 @@ export const Select: Story = {
         "NonCommercialSocialRemixing",
         "CommercialRemixingLicenseTerms",
         "CommercialUseLicenseTerms",
+        "CommercialUseLicenseTermsWithExpiration",
         "No License",
       ],
       mapping: {
         NonCommercialSocialRemixing: nonCommercialSocialRemixingLicenseTerms,
         CommercialRemixingLicenseTerms: commercialRemixingLicenseTerms,
         CommercialUseLicenseTerms: commercialUseLicenseTerms,
+        CommercialUseLicenseTermsWithExpiration: commercialUseLicenseTermsWithExpiration,
         "No License": noLicenseTerms,
       },
     },

--- a/packages/storykit/src/constants/pil-flavors.ts
+++ b/packages/storykit/src/constants/pil-flavors.ts
@@ -24,12 +24,28 @@ export const commercialUseLicenseTerms: PILTerms = {
   commercialUse: true,
   commercializerCheck: "0x0000000000000000000000000000000000000000",
   currency: "0xb132a6b7ae652c974ee1557a3521d53d18f6739f",
-  derivativesAllowed: true,
+  derivativesAllowed: false,
   derivativesApproval: false,
   derivativesAttribution: true,
   derivativesReciprocal: false,
   derivativesRevenueCelling: 0,
   expiration: "never",
+  uRI: "",
+}
+
+export const commercialUseLicenseTermsWithExpiration: PILTerms = {
+  commercialAttribution: true,
+  commercialRevenueCelling: 0,
+  commercialRevenueShare: 0,
+  commercialUse: true,
+  commercializerCheck: "0x0000000000000000000000000000000000000000",
+  currency: "0xb132a6b7ae652c974ee1557a3521d53d18f6739f",
+  derivativesAllowed: false,
+  derivativesApproval: false,
+  derivativesAttribution: true,
+  derivativesReciprocal: false,
+  derivativesRevenueCelling: 0,
+  expiration: "1736866800000",
   uRI: "",
 }
 


### PR DESCRIPTION
This PR fixes the formatting of the expiration field in LicenseTermsList.
<img width="932" alt="image" src="https://github.com/user-attachments/assets/20adc0a7-2598-410d-a72f-9ef3411c997c" />
