### PR TITLE
fix `Asset` type definition

### DIFF
--- a/packages/storykit/package.json
+++ b/packages/storykit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storyprotocol/storykit",
   "author": "storyprotocol engineering <eng@storyprotocol.xyz>",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/storykit/src/types/assets.ts
+++ b/packages/storykit/src/types/assets.ts
@@ -21,7 +21,7 @@ export type Asset = {
   ancestorCount: number
   descendantCount: number
   parentCount?: number
-  childCount?: number
+  childrenCount?: number
   rootCount?: number
   parentIpIds: Address[] | null
   childIpIds: Address[] | null


### PR DESCRIPTION
This PR fixes incorrect type definition of `Asset`.
`childCount` should be `childrenCount`