### PR TITLE
Fix some params potential risk

### DIFF
--- a/packages/storykit/src/providers/StoryKitProvider/StoryKitProvider.tsx
+++ b/packages/storykit/src/providers/StoryKitProvider/StoryKitProvider.tsx
@@ -37,9 +37,9 @@ export const StoryKitProvider = ({
   defaultCurrency,
   theme = "default",
   mode,
-  rpcUrl,
-  apiKey,
-  appId,
+  rpcUrl = "",
+  apiKey = "",
+  appId = "",
   children,
 }: StoryKitProviderOptions) => {
   //


### PR DESCRIPTION
Set the default value to an empty string for the rpcUrl, apiKey and appId properties of StoryKitProvider.

Because:
    In the StoryKitProvider component, we used to deal with `rpcUrl,` `apiKey` and `appId` attributes. When users don't pass these attributes, their values will be `undefined`. This may lead to the need for additional undefined checks in the subsequent code, which increases the complexity of the code and the potential risk of errors.