### PR TITLE
fix: `assetChildrenData` data handling according to API update

### DIFF
--- a/packages/storykit/package.json
+++ b/packages/storykit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storyprotocol/storykit",
   "author": "storyprotocol engineering <eng@storyprotocol.xyz>",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/storykit/src/providers/IpProvider/IpProvider.tsx
+++ b/packages/storykit/src/providers/IpProvider/IpProvider.tsx
@@ -135,8 +135,15 @@ export const IpProvider = ({
     isFetched: isAssetParentDataFetched,
   } = useQuery<AssetEdges[] | undefined>({
     queryKey: [RESOURCE_TYPE.ASSET_EDGES, ipId, "parents"],
-    queryFn: () =>
-      listResource(RESOURCE_TYPE.ASSET_EDGES, chain.name as STORYKIT_SUPPORTED_CHAIN, fetchParentEdgeOptions),
+    queryFn: async () => {
+      const response = await listResource(
+        RESOURCE_TYPE.ASSET_EDGES,
+        chain.name as STORYKIT_SUPPORTED_CHAIN,
+        fetchParentEdgeOptions
+      )
+
+      return response.data
+    },
     enabled: queryOptions.assetParentsData,
   })
 


### PR DESCRIPTION
This PR updates `assetChildrenData` based on the API update.
Since this data is used only in a WIP component, it should have no impact on the StoryKit component.
Additionally, the `assetChildrenData` type was originally correct, and its usage cases are fine.