### PR TITLE
Update IpProvider.mdx

### DIFF
--- a/packages/storykit/src/providers/IpProvider/__docs__/IpProvider.mdx
+++ b/packages/storykit/src/providers/IpProvider/__docs__/IpProvider.mdx
@@ -66,7 +66,7 @@ The IpProvider provides the following data to its children:
 - **isNftDataLoading** - NFT Metadata loading state.
 - **ipLicenseData** - Licenses attached to the IP Asset.
 - **isipLicenseDataLoading** - IPA License Terms data loading state.
-- **licenseTermsData** - The License Terams details including the id, template address and list of license terms.
+- **licenseTermsData** - The License Terms details including the id, template address and list of license terms.
 - **isLicenseTermsDataLoading** - License Terms data loading state.
 - **licenseData** - IP Asset minted Licenses.
 - **isLicenseDataLoading** - License data loading state.


### PR DESCRIPTION
This PR fixes a typo in the documentation comments where "Terms" was incorrectly spelled as "Terams"