### PR TITLE
Fix Grammar and Article Usage

### DIFF
--- a/examples/simple-setup/README.md
+++ b/examples/simple-setup/README.md
@@ -1,6 +1,6 @@
 # Simple Setup Example
 
-This example demonstrates a simple setup of StoryKit;
+This example demonstrates a simple setup of StoryKit:
 - wraps the app with the `StoryKitProvider` and specifies the chain in [`app/Providers.tsx`](./app/Providers.tsx)
 - uses the `IpProvider` to pass the IP data to child components in [`app/page.tsx`](./app/page.tsx)
 - the [`IpHeader`](./app/IpHeader.tsx) component uses the `IpProviders` `useIpContext` hook to access the IP data

--- a/packages/storykit/src/providers/StoryKitProvider/StoryKitProvider.tsx
+++ b/packages/storykit/src/providers/StoryKitProvider/StoryKitProvider.tsx
@@ -70,7 +70,7 @@ export const StoryKitProvider = ({
 export const useStoryKitContext = () => {
   const context = React.useContext(StoryKitContext)
   if (!context) {
-    throw new Error("useStoryKitContext must be used within an StoryKitProvider")
+    throw new Error("useStoryKitContext must be used within a StoryKitProvider")
   }
   return context
 }


### PR DESCRIPTION

## Reason
1. Changed semicolon to colon for better readability
2. Fixed article usage ("an" to "a") before "StoryKitProvider"

