### PR TITLE
fix: merge `ipMetadata` with ipfs data

### DIFF
--- a/packages/storykit/package.json
+++ b/packages/storykit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storyprotocol/storykit",
   "author": "storyprotocol engineering <eng@storyprotocol.xyz>",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/storykit/src/lib/api.ts
+++ b/packages/storykit/src/lib/api.ts
@@ -61,3 +61,9 @@ export async function listResource<T>(
     console.error(error)
   }
 }
+
+export async function getMetadataFromIpfs(ipfsUrl: string) {
+  const metadata = await fetch(ipfsUrl).then((res) => res.json())
+  console.log("@@ metadata", metadata)
+  return metadata
+}


### PR DESCRIPTION
This PR introduces new `ipMetadata` fetching.
- remove `metadataJson` from`/assets/:ipid/metadata`
- fetch directly from `ipfs`

it will help reduce api risk.

keep data structure for backwards compatibility,