### PR TITLE
fix: Fix variable naming convention for isipLicenseDataLoading

### DIFF
--- a/packages/storykit/src/providers/IpProvider/IpProvider.tsx
+++ b/packages/storykit/src/providers/IpProvider/IpProvider.tsx
@@ -46,7 +46,7 @@ const IpContext = React.createContext<{
   isAssetChildrenDataLoading: boolean
   isIpaMetadataLoading: boolean
   ipLicenseData: IPLicenseTerms[] | undefined
-  isipLicenseDataLoading: boolean
+  isIpLicenseDataLoading: boolean
   licenseTermsData: LicenseTerms[] | undefined
   isLicenseTermsDataLoading: boolean
   licenseData: License[] | undefined
@@ -226,7 +226,7 @@ export const IpProvider = ({
 
   // Fetch IP License Terms data
   const {
-    isLoading: isipLicenseDataLoading,
+    isLoading: isIpLicenseDataLoading,
     data: ipLicenseData,
     refetch: refetchIpLicenseData,
     isFetched: isIpLicenseDataFetched,
@@ -360,7 +360,7 @@ export const IpProvider = ({
         ipaMetadata,
         isIpaMetadataLoading: isIpaMetadataLoading || isLoadingFromIpfs,
         ipLicenseData: ipLicenseData?.data,
-        isipLicenseDataLoading,
+        isIpLicenseDataLoading,
         licenseTermsData,
         isLicenseTermsDataLoading,
         licenseData: licenseData?.data,


### PR DESCRIPTION
I noticed that the variable `isipLicenseDataLoading` doesn't follow the standard camelCase naming convention in JavaScript/TypeScript.
According to best practices, the correct name should be `isIpLicenseDataLoading` to ensure consistency and readability. 

This change aligns with our codebase standards.