### PR TITLE
chore: Fix incorrect request body syntax in listResource in api.ts

### DIFF
--- a/packages/storykit/src/lib/api.ts
+++ b/packages/storykit/src/lib/api.ts
@@ -50,7 +50,7 @@ export async function listResource<T>(
         "X-CHAIN": options?.chain || _chain.name || STORYKIT_SUPPORTED_CHAIN.STORY_TESTNET,
       },
       cache: "no-cache",
-      ...(options && { body: JSON.stringify({ options }) }),
+      ...(options && { body: JSON.stringify(options) }),
     })
     if (res.ok) {
       return res.json()


### PR DESCRIPTION
### Description 
I noticed a  bug in the `listResource` function where the request body was being formed incorrectly. Instead of passing `{ options }`, it should directly pass the `options` object.
