### PR TITLE
fix: Update `licenseTermsData` to Include Off-Chain Data

### DIFF
--- a/packages/storykit/package.json
+++ b/packages/storykit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storyprotocol/storykit",
   "author": "storyprotocol engineering <eng@storyprotocol.xyz>",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/storykit/src/lib/api.ts
+++ b/packages/storykit/src/lib/api.ts
@@ -64,6 +64,5 @@ export async function listResource<T>(
 
 export async function getMetadataFromIpfs(ipfsUrl: string) {
   const metadata = await fetch(ipfsUrl).then((res) => res.json())
-  console.log("@@ metadata", metadata)
   return metadata
 }

--- a/packages/storykit/src/types/assets.ts
+++ b/packages/storykit/src/types/assets.ts
@@ -80,7 +80,9 @@ export type PILTerms = {
   derivativesReciprocal: boolean
   derivativesRevenueCelling: number
   expiration: string
+  // @deprecated, use uri instead
   uRI: string
+  uri?: string
 }
 
 export type IPLicenseTerms = {
@@ -109,6 +111,10 @@ export interface Trait {
   max_value?: number
 }
 
+export interface LicenseOffChainData {
+  aiLearningModels?: boolean
+}
+export type PILTermsWithOffChainData = PILTerms & LicenseOffChainData
 export type LicenseTerms = {
   id: string
   // json: string
@@ -116,6 +122,7 @@ export type LicenseTerms = {
   licenseTemplate: Address
   blockNumber: string
   blockTime: string
+  terms: PILTermsWithOffChainData
 }
 
 export type LicenseToken = {


### PR DESCRIPTION
This PR updates `licenseTermsData` to support off-chain data, ensuring flexibility in handling licensing information. Additionally, it includes a fix for the `LicenseTerms` type to improve consistency and accuracy